### PR TITLE
Add glossary definitions for 'constructor' and 'selector'

### DIFF
--- a/glossary/constructor.org
+++ b/glossary/constructor.org
@@ -2,7 +2,7 @@
 
 Um procedimento que _constrói_ (_constructs_) um valor de um tipo a partir de argumentos amigáveis ao usuário. É boa prática que o nome deste seja o nome do tipo que constrói prefixado com `make-`.
 
-Este procedimento deve retornar .. que represente o _objeto_ construído, de tal maneira que informações relevantes possam ser adquiridas via _seletores_.
+Este procedimento deve retornar um valor que represente o _objeto_ construído, de tal maneira que informações relevantes possam ser adquiridas via _seletores_.
 
 Fontes:
 - SICP, seção 2.1

--- a/glossary/constructor.org
+++ b/glossary/constructor.org
@@ -1,6 +1,6 @@
 * Construtor (construtor)
 
-Um procedimento que _constrói_ (_constructs_) um tipo a partir de argumentos amigáveis ao usuário. É boa prática que o nome deste seja o nome do tipo que constrói prefixado com `make-`.
+Um procedimento que _constrói_ (_constructs_) um valor de um tipo a partir de argumentos amigáveis ao usuário. É boa prática que o nome deste seja o nome do tipo que constrói prefixado com `make-`.
 
 Este procedimento deve retornar .. que represente o _objeto_ construído, de tal maneira que informações relevantes possam ser adquiridas via _seletores_.
 

--- a/glossary/constructor.org
+++ b/glossary/constructor.org
@@ -1,0 +1,9 @@
+* Construtor (construtor)
+
+Um procedimento que _constrói_ (_constructs_) um tipo a partir de argumentos amigáveis ao usuário. É boa prática que o nome deste seja o nome do tipo que constrói prefixado com `make-`.
+
+Este procedimento deve retornar .. que represente o _objeto_ construído, de tal maneira que informações relevantes possam ser adquiridas via _seletores_.
+
+Fontes:
+- SICP, seção 2.1
+- P. H. Winston, B. Horn - Lisp 2nd edition, capítulo 5

--- a/glossary/selector.org
+++ b/glossary/selector.org
@@ -1,0 +1,7 @@
+* Selector (seletor)
+
+Um tipo de procedimento com a função de extrair informações de uma representação elaborada por um construtor. É boa prática que o nome do tipo de dados esperado pelo seletor esteja presente no nome do mesmo - dessa forma, fica evidente ao usuário (e para o você de daqui à dois anos) o que esse procedimento faz.
+
+Fontes:
+- SICP, seção 2.1
+- P. H. Winston, B. Horn - Lisp 2nd edition, capítulo 5

--- a/glossary/selector.org
+++ b/glossary/selector.org
@@ -1,6 +1,6 @@
 * Selector (seletor)
 
-Um tipo de procedimento com a função de extrair informações de uma representação elaborada por um construtor. É boa prática que o nome do tipo de dados esperado pelo seletor esteja presente no nome do mesmo - dessa forma, fica evidente ao usuário (e para o você de daqui à dois anos) o que esse procedimento faz.
+Um procedimento que extrai informações de uma representação elaborada por um construtor. É boa prática que o nome do tipo de dados esperado pelo seletor esteja presente no nome do mesmo - dessa forma, fica evidente ao usuário (e para o você de daqui à dois anos) o que esse procedimento faz.
 
 Fontes:
 - SICP, seção 2.1


### PR DESCRIPTION
Também já criei o diretório `glossary/`.